### PR TITLE
Fixes copyright symbol at the start of some tags

### DIFF
--- a/lib/mp4info.rb
+++ b/lib/mp4info.rb
@@ -160,8 +160,6 @@ class MP4Info
         id = id[1..-1]
       end
 
-      if id.bytes.to_a[0] == 169 
-      end
       id = id.upcase
       
       printf "%s%s: %d bytes\n", ' ' * ( 2 * level ), id, size if $DEBUG


### PR DESCRIPTION
Some tags seem to be prefixed by the symbol "\xA9", the copyright symbol. The previous attempt at fixing this doesn't seem to work on Ruby 1.9.3.

The attached commit fixes it by unpacking the tag ID string, seeing if the first char is \xA9, and stripping it if it is.
