### PR TITLE
Compare copyright prefix in a more encoding safe way

### DIFF
--- a/lib/mp4info.rb
+++ b/lib/mp4info.rb
@@ -155,7 +155,7 @@ class MP4Info
         raise "Parse error"
       end
       
-      if id.unpack("M")[0][0] == "\xA9"
+      if id[0].ord == 0xa9
         # strip copyright sign at the beginning
         id = id[1..-1]
       end


### PR DESCRIPTION
id is a ASCII-8BIT string but the literal "\xa9" could be
UTF-8 string which in that case Ruby won't conceder them equal.
This is probably because "\xa9" is an invalid UTF-8 string etc.

"\xa9".force_encoding(Encoding::ASCII_8BIT) == "\xa9".force_encoding(Encoding::UTF_8) => false
